### PR TITLE
risc-v-cookbook/overview: describe separation of duties

### DIFF
--- a/docs/risc-v-cookbook/overview/index.rst
+++ b/docs/risc-v-cookbook/overview/index.rst
@@ -43,6 +43,12 @@ Here is a typical workflow:
 .. image:: /images/workflow.png
    :alt: Typical workflow
 
+The produced image will take all packages that are not device specific from the
+Ubuntu archive. This ensures that devices will receive all package updates.
+
+All device specific packages will be taken from the public PPA. It will be the
+device PPA owner's obligation to ensure security updates.
+
 Setup Launchpad
 ---------------
 


### PR DESCRIPTION
Describe that most packages should come from Ubuntu archives and the responsibility of the PPA owner to provide security updates.