### PR TITLE
boards/raspberry-pi-other: correct link to rpi-imager

### DIFF
--- a/docs/boards/tutorials/raspberry-pi-other.rst
+++ b/docs/boards/tutorials/raspberry-pi-other.rst
@@ -87,7 +87,7 @@ Flashing the boot media
 #. Once writing is complete, it will re-read the media to verify the image was
    written successfully, then prompt you to remove your media
 
-.. _snap of rpi-imager: https://snapstore.io/rpi-imager
+.. _snap of rpi-imager: https://snapcraft.io/rpi-imager
 .. _Raspberry Pi software page: https://www.raspberrypi.com/software/
 
 


### PR DESCRIPTION
The snap store is at https://snapcraft.io now.