### PR TITLE
Remove Ubuntu support warning for VisionFive 2 Lite

### DIFF
--- a/docs/boards/how-to/starfive-visionfive-2-lite.rst
+++ b/docs/boards/how-to/starfive-visionfive-2-lite.rst
@@ -5,11 +5,6 @@ Install Ubuntu on the StarFive VisionFive 2 Lite
 
 The `StarFive VisionFive 2 Lite`_ is a RISC-V based :term:`SBC`.
 
-.. warning::
-
-    The StarFive VisionFive 2 Lite is not yet supported by official Ubuntu
-    images.
-
 Using the pre-installed server image
 ------------------------------------
 


### PR DESCRIPTION
Removed warning about lack of official Ubuntu support for StarFive VisionFive 2 Lite. Support was added in Noble 24.04.4.