### PR TITLE
how-to: remove RISC-V references to release 24.10 and 25.04

### DIFF
--- a/docs/boards/how-to/deepcomputing-fml13v01.rst
+++ b/docs/boards/how-to/deepcomputing-fml13v01.rst
@@ -65,19 +65,16 @@ Using the live server image
 The live installer image is used to install Ubuntu to an eMMC, USB, or NVMe
 drive. To boot the live image, U-Boot must be installed on the SPI flash.
 
-.. warning::
-
-    The installer in Ubuntu 24.10 and 25.04 fails to invoke flash-kernel and
-    grub-update. The system is booted with the device-tree from U-Boot and
-    fails with an outdated U-Boot. Please, update U-Boot as described below.
-
 
 Install U-Boot to the SPI flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Download one of the supported images:
 
-   * `Ubuntu 25.04 (Plucky Puffin) Server live installer <https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso>`_
+   .. ubuntu-images:
+       :releases: noble
+       :image-types: live-server
+       :archs: riscv64
 
 #. Flash the pre-installed server image to a microSD card (see
    :ref:`flash-images-to-a-microsd-card`)

--- a/docs/boards/how-to/milk-v-mars.rst
+++ b/docs/boards/how-to/milk-v-mars.rst
@@ -62,12 +62,6 @@ drive. To boot the live image, U-Boot must be installed on the SPI flash.
     The vendor U-Boot is not compatible with :term:`EBBR` and cannot boot
     Ubuntu without manual changes.
 
-.. warning::
-
-    The installer in Ubuntu 24.10 and 25.04 fails to invoke flash-kernel and
-    grub-update. The system is booted with the device-tree from U-Boot and
-    fails with an outdated U-Boot. Please, update U-Boot as described below.
-
 
 Install U-Boot to the SPI flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/boards/how-to/pine64-star64.rst
+++ b/docs/boards/how-to/pine64-star64.rst
@@ -62,12 +62,6 @@ drive. To boot the live image, U-Boot must be installed on the SPI flash.
     The vendor U-Boot is not compatible with :term:`EBBR` and cannot boot
     Ubuntu without manual changes.
 
-.. warning::
-
-    The installer in Ubuntu 25.04 fails to invoke flash-kernel and grub-update.
-    The system is booted with the device-tree from U-Boot and fails with an
-    outdated U-Boot. Please, update U-Boot as described below.
-
 
 Install U-Boot to the SPI flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/boards/how-to/starfive-visionfive-2.rst
+++ b/docs/boards/how-to/starfive-visionfive-2.rst
@@ -63,12 +63,6 @@ flash.
     The vendor U-Boot is not compatible with :term:`EBBR` and cannot boot
     Ubuntu without manual changes.
 
-.. warning::
-
-    The installer in Ubuntu 24.10 and 25.04 fails to invoke flash-kernel and
-    grub-update. The system is booted with the device-tree from U-Boot and
-    fails with an outdated U-Boot. Please, update U-Boot as described below.
-
 
 Install U-Boot to the SPI flash
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We no longer support releases 24.10 and 25.04.