### PR TITLE
Add Ubuntu image directive for StarFive VisionFive 2 Lite

### DIFF
--- a/docs/boards/how-to/ubuntu_supported/starfive-visionfive-2-lite.rst
+++ b/docs/boards/how-to/ubuntu_supported/starfive-visionfive-2-lite.rst
@@ -10,6 +10,11 @@ Using the pre-installed server image
 
 #. Download one of the supported images.
 
+   .. ubuntu-images::
+       :releases: noble
+       :archs: riscv64
+       :matches: 24\.04\.([4-9]|\d{2,})-preinstalled-server-riscv64\+jh7110\.img\.xz
+
 #. Flash the pre-installed server image to a microSD card (see
    :ref:`flash-images-to-a-microsd-card`)
 
@@ -107,6 +112,13 @@ Boot the live server image
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. Download one of the supported images.
+
+   .. ubuntu-images::
+       :releases: noble
+       :image-types: live-server
+       :archs: riscv64
+       :matches: 24\.04\.([4-9]|\d{2,})-live-server-riscv64\.iso
+
 
 #. Flash the live server image to a microSD card (see
    :ref:`flash-images-to-a-microsd-card`)


### PR DESCRIPTION
Added a directive to include supported Ubuntu images for the StarFive VisionFive 2 Lite.

Fixes https://github.com/canonical/ubuntu-hw-support/issues/48