### PR TITLE
image-cookbook: correct ukpack download path

### DIFF
--- a/docs/image-cookbook/howto/packaging/package_kernel.rst
+++ b/docs/image-cookbook/howto/packaging/package_kernel.rst
@@ -20,7 +20,7 @@ First, clone the ``ukpack`` repository:
 
 .. prompt:: none $ auto
 
-    $ git clone https://kernel.ubuntu.com/forgejo/esmil/ukpack.git
+    $ git clone https://github.com/ubuntu/ukpack.git
 
 Next, clone the custom kernel repository:
 


### PR DESCRIPTION
https://kernel.ubuntu.com/forgejo/esmil/ukpack.git is not publicly reachable.