### PR TITLE
Describe usage of livecd-rootfs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -61,6 +61,7 @@ KMS
 KVM
 Kbits
 Keyid
+kubuntu
 LXC
 LicheeRV
 MBR
@@ -270,6 +271,7 @@ tx
 txt
 uaccess
 ubuntu
+ubuntustudio
 ukpack
 umount
 unformatted
@@ -279,9 +281,11 @@ Upgrader
 userland
 usr
 utilize
+vmdk
 whois
 wifi
 wokeignore
+xubuntu
 xz
 yaml
 yml

--- a/docs/image-cookbook/howto/images/create_installer_image.rst
+++ b/docs/image-cookbook/howto/images/create_installer_image.rst
@@ -1,0 +1,102 @@
+.. SPDX-License-Identifier: CC-BY-SA-4.0
+
+.. _create-installer-image:
+
+Create installer image
+=======================
+
+As of 2026 :lp-pkg:`livecd-rootfs` is the tool used by Canonical to create
+both preinstalled images as well as installer images.
+
+You can install it with
+
+.. prompt:: text $ auto
+
+    $ sudo apt-get update
+    $ sudo apt-get livecd-rootfs
+
+The package provides three scripts in /usr/share/livecd-rootfs/live-build/auto/:
+
+clean
+    Remove build artifacts
+
+config
+    Configure build
+
+build
+    Execute the build
+
+Here is an example of building a riscv64 ubuntu-server installer image:
+
+.. prompt:: text $ auto
+
+    sudo /usr/share/livecd-rootfs/live-build/auto/clean
+
+    sudo \
+    ARCH=riscv64 \
+    PROJECT=ubuntu-server \
+    SUBPROJECT=live \
+    SUITE=resolute \
+    /usr/share/livecd-rootfs/live-build/auto/config
+
+    sudo \
+    ARCH=riscv64 \
+    PROJECT=ubuntu-server \
+    SUBPROJECT=live \
+    SUITE=resolute \
+    /usr/share/livecd-rootfs/live-build/auto/build
+
+The output of this build is file 'livecd.ubuntu-server.iso*.
+
+Which image is built is controlled by environment variables.
+
++---------------+----------+-----------------------------------------------------------------------------+
+| Variable      | Required | Usage                                                                       |
++===============+==========+=============================================================================+
+| ARCH          | required | Ubuntu architecture (e.g. risc       v64)                                   |
++---------------+----------+-----------------------------------------------------------------------------+
+| EXTRA_PPAS    | optional | A space separated string, e.g. ``"user1/ppa1 user1/ppa2 user2/ppa3"``.      |
+|               |          | The PPA string may contain a pin priority, e.g. ``"user1/ppa1:300"``.       |
++---------------+----------+-----------------------------------------------------------------------------+
+| EXTRA_SNAPS   | optional |                                                                             |
++---------------+----------+-----------------------------------------------------------------------------+
+| IMAGEFORMAT   | optional | *ext2*, *ext3*, *ext4*, *plain*, *ubuntu-image*, *none*                     |
++---------------+----------+-----------------------------------------------------------------------------+
+| IMAGE_TARGETS | optional | *disk-image*, *qcow2*, *squashfs*, *tarball*, *vmdk*                        |
++---------------+----------+-----------------------------------------------------------------------------+
+| MIRROR        | optional | Mirror used for installing packages. If not set, is selected automatically. |
++---------------+----------+-----------------------------------------------------------------------------+
+| PROJECT       | required | *ubuntu-cpc*, *ubuntu-server*, *ubuntustudio*, *ubuntu*, *kubuntu*, ...     |
++---------------+----------+-----------------------------------------------------------------------------+
+| PROPOSED      | optional | ``PROPOSED=1`` selects the proposed pocket for packages                     |
++---------------+----------+-----------------------------------------------------------------------------+
+| SEEDMIRROR    | internal | Defaults to https://people.canonical.com/~ubuntu-archive/seeds/             |
++---------------+----------+-----------------------------------------------------------------------------+
+| SUBARCH       | optional | Used only for ``$IMAGEFORMAT="ubuntu-image"``                               |
++---------------+----------+-----------------------------------------------------------------------------+
+| SUBPROJECT    | optional | E.g. *live* (for ubuntu-server), *minimized* (for minimized images)         |
++---------------+----------+-----------------------------------------------------------------------------+
+| SUITE         | required | Ubuntu release, e.g. *resolute* for Ubuntu 26.04                            |
++---------------+----------+-----------------------------------------------------------------------------+
+
+Here are some useful property combinations:
+
++----------------------------+---------------+------------+-------------+
+| Image                      | PROJECT       | SUBPROJECT | IMAGEFORMAT |
++============================+===============+============+=============+
+| RISC-V preinstalled server | ubuntu-cpc    | generic    | ext4        |
++----------------------------+---------------+------------+-------------+
+| Ubuntu server installer    | ubuntu-server | live       |             |
++----------------------------+---------------+------------+-------------+
+| Ubuntu desktop             | ubuntu        | live       |             |
++----------------------------+---------------+------------+-------------+
+| Xubuntu desktop            | xubuntu       | live       |             |
++----------------------------+---------------+------------+-------------+
+| Xubuntu minimal desktop    | xubuntu       | minimal    |             |
++----------------------------+---------------+------------+-------------+
+
+For a full overview consult the livecd-rootfs source code available at
+https://git.launchpad.net/ubuntu/+source/livecd-rootfs.
+
+There are significant changes between the livecd-rootfs packages of different
+Ubuntu releases.

--- a/docs/image-cookbook/howto/images/customize_installer_image.rst
+++ b/docs/image-cookbook/howto/images/customize_installer_image.rst
@@ -1,9 +1,9 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0
 
-.. _creating-customized-live-installer-images:
+.. _customize-installer-images:
 
-Creating customized installer images
-====================================
+Customize installer images
+===========================
 
 Both pre-installed images and installer images are available for Ubuntu.
 

--- a/docs/image-cookbook/howto/images/index.rst
+++ b/docs/image-cookbook/howto/images/index.rst
@@ -7,4 +7,5 @@ Images
    :maxdepth: 2
 
    create_image
+   create_installer_image
    customize_installer_image

--- a/docs/image-cookbook/howto/images/index.rst
+++ b/docs/image-cookbook/howto/images/index.rst
@@ -7,4 +7,4 @@ Images
    :maxdepth: 2
 
    create_image
-   create_installer_image
+   customize_installer_image

--- a/docs/image-cookbook/tutorial/create_image.rst
+++ b/docs/image-cookbook/tutorial/create_image.rst
@@ -22,7 +22,7 @@ Clone the gadget repository
 
 .. note::
 
-    The ``main`` branch should contain a gadget targetting current Ubuntu **development release**.
+    The ``main`` branch should contain a gadget targeting current Ubuntu **development release**.
     LTS branches like ``resolute`` and ``noble`` are available (add ``-b <branch>`` to the command below).
 
     If the target hardware does not support the RVA23 profile, ``noble`` is the only possible option,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ hardware.
 
 * **Getting started**: :ref:`Image Cookbook overview <image-overview>` • :ref:`Your first Ubuntu image <your-first-ubuntu-image>`
 * **Image creation**: :ref:`Create image with ubuntu-image <create-customized-image-with-ubuntu-image>`
+  • :ref:`Create installer image <create-installer-image>`
   • :ref:`Customize installer images <customize-installer-images>`
 * **Kernel packages**: :ref:`Your first kernel package <your-first-kernel-package>` • :ref:`Package a custom kernel <package-kernel>`
 * **Packaging**: :ref:`Package binaries as .deb <package-binaries>` • :ref:`Repackage binaries <repackage-binaries>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,7 +85,8 @@ Launchpad infrastructure to creating distributable Ubuntu images for new
 hardware.
 
 * **Getting started**: :ref:`Image Cookbook overview <image-overview>` • :ref:`Your first Ubuntu image <your-first-ubuntu-image>`
-* **Image creation**: :ref:`Create image with ubuntu-image <create-customized-image-with-ubuntu-image>` • :ref:`Create installer images <creating-customized-live-installer-images>`
+* **Image creation**: :ref:`Create image with ubuntu-image <create-customized-image-with-ubuntu-image>`
+  • :ref:`Customize installer images <customize-installer-images>`
 * **Kernel packages**: :ref:`Your first kernel package <your-first-kernel-package>` • :ref:`Package a custom kernel <package-kernel>`
 * **Packaging**: :ref:`Package binaries as .deb <package-binaries>` • :ref:`Repackage binaries <repackage-binaries>`
 


### PR DESCRIPTION
Add a new page describing the usage of livecd-rootfs to create installer images.